### PR TITLE
Fix misleading benchmark

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Introduction
 
-Naive performance test of doing type assertion using:
+Native performance test of doing type assertion using:
 
  * The static way
 
@@ -11,8 +11,10 @@ or...
 # Results
 
 ```
-BenchmarkAppendNativeTypeAssertion       5000000           666 ns/op
-BenchmarkAppendReflectionTypeAssertion   5000000           529 ns/op
+goos: darwin
+goarch: amd64
+BenchmarkAppendNativeTypeAssertion-8       10000000       129 ns/op      56 B/op       3 allocs/op
+BenchmarkAppendReflectionTypeAssertion-8   10000000       144 ns/op      56 B/op       3 allocs/op
 ```
 
 # Thanks to

--- a/native.go
+++ b/native.go
@@ -31,6 +31,12 @@ func (c *FloatCol) AppendNativeTypeAssertion(row interface{}) error {
 		c.rows = append(c.rows, float64(value))
 	case uint64:
 		c.rows = append(c.rows, float64(value))
+	case string:
+		num, err := strconv.ParseFloat(value, 64)
+		if err != nil {
+			return err
+		}
+		c.rows = append(c.rows, num)
 	default:
 		num, err := strconv.ParseFloat(fmt.Sprint(row), 64)
 		if err != nil {

--- a/reflection.go
+++ b/reflection.go
@@ -14,6 +14,12 @@ func (c *FloatCol) AppendReflectionTypeAssertion(row interface{}) error {
 		c.rows = append(c.rows, float64(rv.Int()))
 	case reflect.Float32, reflect.Float64:
 		c.rows = append(c.rows, rv.Float())
+	case reflect.String:
+		num, err := strconv.ParseFloat(rv.String(), 64)
+		if err != nil {
+			return err
+		}
+		c.rows = append(c.rows, num)
 	default:
 		num, err := strconv.ParseFloat(rv.String(), 64)
 		if err != nil {


### PR DESCRIPTION
* Native type assertion appeared slower than reflection b/c of an unnecessary call to `fmt.Sprint()`
* Update results in README